### PR TITLE
Add support for batching write calls

### DIFF
--- a/save.go
+++ b/save.go
@@ -83,3 +83,79 @@ func (s *DB) Save(data interface{}) error {
 	})
 	return err
 }
+
+
+// BatchSave a structure
+func (s *DB) BatchSave(data interface{}) error {
+	if !structs.IsStruct(data) {
+		return ErrBadType
+	}
+
+	info, err := extract(data)
+	if err != nil {
+		return err
+	}
+
+	if info.ID == nil {
+		return ErrNoID
+	}
+
+	if info.ID.IsZero() {
+		return ErrZeroID
+	}
+
+	if info.Name == "" {
+		return ErrNoName
+	}
+
+	id, err := toBytes(info.ID.Value())
+	if err != nil {
+		return err
+	}
+
+	err = s.Bolt.Batch(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(info.Name))
+		if err != nil {
+			return err
+		}
+
+		var idx Index
+		for fieldName, idxInfo := range info.Indexes {
+			switch idxInfo.Type {
+			case "unique":
+				idx, err = NewUniqueIndex(bucket, []byte(indexPrefix+fieldName))
+			case "index":
+				idx, err = NewListIndex(bucket, []byte(indexPrefix+fieldName))
+			default:
+				err = ErrBadIndexType
+			}
+
+			if err != nil {
+				return err
+			}
+
+			err = idx.RemoveID(id)
+			if err != nil {
+				return err
+			}
+
+			value, err := toBytes(idxInfo.Field.Value())
+			if err != nil {
+				return err
+			}
+
+			err = idx.Add(value, id)
+			if err != nil {
+				return err
+			}
+		}
+
+		raw, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+
+		return bucket.Put(id, raw)
+	})
+	return err
+}


### PR DESCRIPTION
Just copied the storm.Save function over and changed bolt.Update to bolt.Batch to call the opportunistic batching functionality in BoltDB since there is a one process write block. Just call .BatchSave() now to make sure things get batched together instead of waiting on the write-lock.

Original code is left unchanged.