### PR TITLE
Move JSON code below /codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ db, err := storm.Open("my.db", storm.BoltOptions(0600, &bolt.Options{Timeout: 1 
 
 #### EncodeDecoder
 
-To store the data in BoltDB, Storm encodes it in JSON by default. If you wish to change this behavior you can pass a codec that implements [`storm.EncodeDecoder`](https://godoc.org/github.com/asdine/storm#EncodeDecoder) via the [`storm.Codec`](https://godoc.org/github.com/asdine/storm#Codec) option:
+To store the data in BoltDB, Storm encodes it in JSON by default. If you wish to change this behavior you can pass a codec that implements [`codec.EncodeDecoder`](https://godoc.org/github.com/asdine/storm/codec#EncodeDecoder) via the [`storm.Codec`](https://godoc.org/github.com/asdine/storm#Codec) option:
 
 ```go
 db := storm.Open("my.db", storm.Codec(myCodec))

--- a/codec.go
+++ b/codec.go
@@ -1,24 +1,8 @@
 package storm
 
 import (
-	"encoding/json"
+	"github.com/asdine/storm/codec/json"
 )
 
-// EncodeDecoder represents a codec used to encode and decode entities.
-type EncodeDecoder interface {
-	Encode(v interface{}) ([]byte, error)
-	Decode(b []byte, v interface{}) error
-}
-
 // Defaults to JSON
-type jsonCodec int
-
-func (j jsonCodec) Encode(v interface{}) ([]byte, error) {
-	return json.Marshal(v)
-}
-
-func (j jsonCodec) Decode(b []byte, v interface{}) error {
-	return json.Unmarshal(b, v)
-}
-
-var defaultCodec = new(jsonCodec)
+var defaultCodec = json.Codec

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -1,0 +1,7 @@
+package codec
+
+// EncodeDecoder represents a codec used to encode and decode entities.
+type EncodeDecoder interface {
+	Encode(v interface{}) ([]byte, error)
+	Decode(b []byte, v interface{}) error
+}

--- a/codec/json/json.go
+++ b/codec/json/json.go
@@ -1,0 +1,18 @@
+package json
+
+import (
+	"encoding/json"
+)
+
+// Codec that encodes to and decodes from JSON.
+var Codec = new(jsonCodec)
+
+type jsonCodec int
+
+func (j jsonCodec) Encode(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func (j jsonCodec) Decode(b []byte, v interface{}) error {
+	return json.Unmarshal(b, v)
+}

--- a/codec/json/json_test.go
+++ b/codec/json/json_test.go
@@ -1,0 +1,11 @@
+package json
+
+import (
+	"testing"
+
+	"github.com/asdine/storm/codec"
+)
+
+func TestJSON(t *testing.T) {
+	codec.RountripTester(t, Codec)
+}

--- a/codec/test_helpers.go
+++ b/codec/test_helpers.go
@@ -6,16 +6,14 @@ import (
 	"testing"
 
 	"reflect"
-
-	"github.com/asdine/storm"
 )
 
 type testStruct struct {
 	Name string
 }
 
-// RountripTester is a test helper to test a storm.EncodeDecoder
-func RountripTester(t *testing.T, c storm.EncodeDecoder, vals ...interface{}) {
+// RountripTester is a test helper to test a EncodeDecoder
+func RountripTester(t *testing.T, c EncodeDecoder, vals ...interface{}) {
 	var val, to interface{}
 	if len(vals) > 0 {
 		if len(vals) != 2 {

--- a/storm.go
+++ b/storm.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/asdine/storm/codec"
 	"github.com/boltdb/bolt"
 )
 
@@ -17,7 +18,7 @@ func BoltOptions(mode os.FileMode, options *bolt.Options) func(*DB) error {
 }
 
 // Codec used to set a custom encoder and decoder. The default is JSON.
-func Codec(c EncodeDecoder) func(*DB) error {
+func Codec(c codec.EncodeDecoder) func(*DB) error {
 	return func(d *DB) error {
 		d.Codec = c
 		return nil
@@ -102,7 +103,7 @@ type DB struct {
 	Path string
 
 	// Handles encoding and decoding of objects
-	Codec EncodeDecoder
+	Codec codec.EncodeDecoder
 
 	// Bolt is still easily accessible
 	Bolt *bolt.DB


### PR DESCRIPTION
To prevent package import cycles, the interface
`EncodeDecoder` is also moved into `codec` where it fits naturally.

Fixes #19