### PR TITLE
Add Count command

### DIFF
--- a/count.go
+++ b/count.go
@@ -1,0 +1,51 @@
+package storm
+
+import (
+	"fmt"
+
+	"github.com/boltdb/bolt"
+	"github.com/fatih/structs"
+)
+
+// Count counts all the records of a bucket
+func (n *Node) Count(data interface{}) (int, error) {
+	if !structs.IsStruct(data) {
+		return 0, ErrBadType
+	}
+
+	info, err := extract(data)
+	if err != nil {
+		return 0, err
+	}
+
+	var count int
+	if n.tx != nil {
+		err = n.count(n.tx, info, &count)
+		return count, err
+	}
+
+	err = n.s.Bolt.View(func(tx *bolt.Tx) error {
+		return n.count(tx, info, &count)
+	})
+	return count, err
+}
+
+func (n *Node) count(tx *bolt.Tx, info *modelInfo, count *int) error {
+	bucket := n.GetBucket(tx, info.Name)
+	if bucket == nil {
+		return fmt.Errorf("bucket %s not found", info.Name)
+	}
+
+	*count = 0
+	c := bucket.Cursor()
+	for k, v := c.First(); k != nil && v != nil; k, v = c.Next() {
+		(*count)++
+	}
+
+	return nil
+}
+
+// Count counts all the records of a bucket
+func (s *DB) Count(data interface{}) (int, error) {
+	return s.root.Count(data)
+}

--- a/count.go
+++ b/count.go
@@ -38,7 +38,10 @@ func (n *Node) count(tx *bolt.Tx, info *modelInfo, count *int) error {
 
 	*count = 0
 	c := bucket.Cursor()
-	for k, v := c.First(); k != nil && v != nil; k, v = c.Next() {
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		if v == nil {
+			continue
+		}
 		(*count)++
 	}
 

--- a/count_test.go
+++ b/count_test.go
@@ -1,0 +1,34 @@
+package storm
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCount(t *testing.T) {
+	dir, _ := ioutil.TempDir(os.TempDir(), "storm")
+	defer os.RemoveAll(dir)
+	db, _ := Open(filepath.Join(dir, "storm.db"))
+
+	for i := 0; i < 100; i++ {
+		w := User{Name: "John", ID: i + 1, Slug: fmt.Sprintf("John%d", i+1), DateOfBirth: time.Now().Add(-time.Duration(i*10) * time.Minute)}
+		err := db.Save(&w)
+		assert.NoError(t, err)
+	}
+
+	count, _ := db.Count(User{})
+	assert.Equal(t, 100, count)
+
+	w := User{Name: "John", ID: 101, Slug: fmt.Sprintf("John%d", 101), DateOfBirth: time.Now().Add(-time.Duration(101*10) * time.Minute)}
+	err := db.Save(&w)
+	assert.NoError(t, err)
+
+	count, _ = db.Count(User{})
+	assert.Equal(t, 101, count)
+}


### PR DESCRIPTION
Sometimes you need to count db objects. To fetch all users in a list with `db.All(&users)` and use the list size is very memory inefficient when you have lots of entries.
I added the possibility for `db.Count(User{})` which counts all elements in that bucket without allocating a large list of Users.