### PR TITLE
Add UseDB option

### DIFF
--- a/options.go
+++ b/options.go
@@ -41,6 +41,16 @@ func Root(root ...string) func(*DB) error {
 	}
 }
 
+// UseDB allow Storm to use an existing open Bolt.DB.
+// Warning: storm.DB.Close() will close the bolt.DB instance.
+func UseDB(b *bolt.DB) func(*DB) error {
+	return func(d *DB) error {
+		d.Path = b.Path()
+		d.Bolt = b
+		return nil
+	}
+}
+
 // Limit sets the maximum number of records to return
 func Limit(limit int) func(*index.Options) {
 	return func(opts *index.Options) {

--- a/storm.go
+++ b/storm.go
@@ -18,7 +18,9 @@ func Open(path string, stormOptions ...func(*DB) error) (*DB, error) {
 	}
 
 	for _, option := range stormOptions {
-		option(s)
+		if err = option(s); err != nil {
+			return nil, err
+		}
 	}
 
 	if s.boltMode == 0 {
@@ -29,9 +31,12 @@ func Open(path string, stormOptions ...func(*DB) error) (*DB, error) {
 		s.boltOptions = &bolt.Options{Timeout: 1 * time.Second}
 	}
 
-	s.Bolt, err = bolt.Open(path, s.boltMode, s.boltOptions)
-	if err != nil {
-		return nil, err
+	// skip if UseDB option is used
+	if s.Bolt == nil {
+		s.Bolt, err = bolt.Open(path, s.boltMode, s.boltOptions)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	s.root = &Node{s: s, rootBucket: s.rootBucket}

--- a/storm_test.go
+++ b/storm_test.go
@@ -61,6 +61,19 @@ func TestNewStormWithStormOptions(t *testing.T) {
 	assert.Equal(t, dc, db2.Codec)
 }
 
+func TestBoltDB(t *testing.T) {
+	dir, _ := ioutil.TempDir(os.TempDir(), "storm")
+	defer os.RemoveAll(dir)
+	bDB, err := bolt.Open(filepath.Join(dir, "bolt.db"), 0600, &bolt.Options{Timeout: 10 * time.Second})
+	assert.NoError(t, err)
+	// no need to close bolt.DB Storm will take of it
+	sDB, err := Open("my.db", UseDB(bDB))
+	assert.NoError(t, err)
+	defer sDB.Close()
+	err = sDB.Save(&SimpleUser{ID: 10})
+	assert.NoError(t, err)
+}
+
 type dummyCodec int
 
 func (c dummyCodec) Encode(v interface{}) ([]byte, error) {


### PR DESCRIPTION
Sometimes it's useful to use an existing open `bolt.DB`.

I have this project that I plan to fully migrate to storm, but either I change how `*bolt.DB` is initialised in that project to use `*storm.DB.Bolt` (not fun), or use an that new function (less intrusive).