### PR TITLE
Add PrefixScan

### DIFF
--- a/node.go
+++ b/node.go
@@ -25,3 +25,9 @@ func (n Node) WithTransaction(tx *bolt.Tx) *Node {
 	n.tx = tx
 	return &n
 }
+
+// Bucket returns the bucket name as a slice from the root.
+// In the normal, simple case this will be empty.
+func (n *Node) Bucket() []string {
+	return n.rootBucket
+}

--- a/scan.go
+++ b/scan.go
@@ -1,0 +1,49 @@
+package storm
+
+import (
+	"bytes"
+
+	"github.com/boltdb/bolt"
+)
+
+// PrefixScan scans the root buckets for keys matching the given prefix.
+func (s *DB) PrefixScan(prefix string) []*Node {
+	return s.root.PrefixScan(prefix)
+}
+
+// PrefixScan scans the buckets in this node for keys matching the given prefix.
+func (n *Node) PrefixScan(prefix string) []*Node {
+
+	if n.tx != nil {
+		return n.prefixScan(n.tx, prefix)
+	}
+
+	var nodes []*Node
+
+	n.s.Bolt.View(func(tx *bolt.Tx) error {
+		nodes = n.prefixScan(tx, prefix)
+		return nil
+	})
+
+	return nodes
+}
+
+func (n *Node) prefixScan(tx *bolt.Tx, prefix string) []*Node {
+
+	prefixBytes := []byte(prefix)
+
+	var nodes []*Node
+
+	var c *bolt.Cursor
+
+	if len(n.rootBucket) > 0 {
+		c = n.GetBucket(tx).Cursor()
+	} else {
+		c = tx.Cursor()
+	}
+
+	for k, _ := c.Seek(prefixBytes); bytes.HasPrefix(k, prefixBytes); k, _ = c.Next() {
+		nodes = append(nodes, n.From(string(k)))
+	}
+	return nodes
+}

--- a/scan_test.go
+++ b/scan_test.go
@@ -1,0 +1,58 @@
+package storm
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrefixScanDB(t *testing.T) {
+	dir, _ := ioutil.TempDir(os.TempDir(), "storm")
+	defer os.RemoveAll(dir)
+	db, _ := Open(filepath.Join(dir, "storm.db"))
+
+	for i := 1; i < 3; i++ {
+		n := db.From(fmt.Sprintf("%d%d", 2015, i))
+		err := n.Save(&SimpleUser{ID: i, Name: "John"})
+		assert.NoError(t, err)
+	}
+
+	for i := 1; i < 4; i++ {
+		n := db.From(fmt.Sprintf("%d%d", 2016, i))
+		err := n.Save(&SimpleUser{ID: i, Name: "John"})
+		assert.NoError(t, err)
+	}
+
+	assert.Len(t, db.PrefixScan("2015"), 2)
+	assert.Len(t, db.PrefixScan("20"), 5)
+
+	buckets2016 := db.PrefixScan("2016")
+	assert.Len(t, buckets2016, 3)
+	count, err := buckets2016[1].Count(&SimpleUser{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	assert.NoError(t, buckets2016[1].One("ID", 2, &SimpleUser{}))
+
+}
+
+func TestPrefixScanNode(t *testing.T) {
+	dir, _ := ioutil.TempDir(os.TempDir(), "storm")
+	defer os.RemoveAll(dir)
+	db, _ := Open(filepath.Join(dir, "storm.db"))
+
+	node := db.From("node")
+
+	for i := 1; i < 3; i++ {
+		n := node.From(fmt.Sprintf("%d%d", 2016, i))
+		err := n.Save(&SimpleUser{ID: i, Name: "John"})
+		assert.NoError(t, err)
+	}
+
+	assert.Len(t, node.PrefixScan("2016"), 2)
+}

--- a/storm.go
+++ b/storm.go
@@ -109,3 +109,9 @@ func (s *DB) From(root ...string) *Node {
 func (s *DB) WithTransaction(tx *bolt.Tx) *Node {
 	return s.root.WithTransaction(tx)
 }
+
+// Bucket returns the root bucket name as a slice.
+// In the normal, simple case this will be empty.
+func (s *DB) Bucket() []string {
+	return s.root.Bucket()
+}


### PR DESCRIPTION
To scan for buckets by prefix.

I assume this bucket handling will live fine on the side of the query language etc. operating on the bucket content,
and that this will not conflict in naming.

I will add RangeScan once we agree on the naming and/or if this is a good idea.

This commits also adds an accessor for the bucket name.