### PR TITLE
Add FieldMatcher

### DIFF
--- a/q/fieldmatcher.go
+++ b/q/fieldmatcher.go
@@ -1,0 +1,32 @@
+package q
+
+import (
+	"reflect"
+)
+
+type fieldMatcherDelegate struct {
+	FieldMatcher
+	Field string
+}
+
+// NewFieldMatcher creates a Matcher for a given field.
+func NewFieldMatcher(field string, fm FieldMatcher) Matcher {
+	return fieldMatcherDelegate{Field: field, FieldMatcher: fm}
+}
+
+// FieldMatcher can be used in NewFieldMatcher as a simple way to create the
+// most common Matcher: A Matcher that evaluates one field's value.
+// For more complex scenarios, implement the Matcher interface directly.
+type FieldMatcher interface {
+	MatchField(v interface{}) (bool, error)
+}
+
+func (r fieldMatcherDelegate) Match(i interface{}) (bool, error) {
+	v := reflect.Indirect(reflect.ValueOf(i))
+	return r.MatchValue(&v)
+}
+
+func (r fieldMatcherDelegate) MatchValue(v *reflect.Value) (bool, error) {
+	field := v.FieldByName(r.Field).Interface()
+	return r.MatchField(field)
+}

--- a/q/tree.go
+++ b/q/tree.go
@@ -20,19 +20,12 @@ type ValueMatcher interface {
 }
 
 type cmp struct {
-	field string
 	value interface{}
 	token token.Token
 }
 
-func (c *cmp) Match(i interface{}) (bool, error) {
-	v := reflect.Indirect(reflect.ValueOf(i))
-	return c.MatchValue(&v)
-}
-
-func (c *cmp) MatchValue(v *reflect.Value) (bool, error) {
-	field := v.FieldByName(c.field)
-	return compare(field.Interface(), c.value, c.token), nil
+func (c *cmp) MatchField(v interface{}) (bool, error) {
+	return compare(v, c.value, c.token), nil
 }
 
 type trueMatcher struct{}
@@ -118,33 +111,39 @@ type strictEq struct {
 	value interface{}
 }
 
-func (s *strictEq) Match(i interface{}) (bool, error) {
-	v := reflect.Indirect(reflect.ValueOf(i))
-	return s.MatchValue(&v)
-}
-
-func (s *strictEq) MatchValue(v *reflect.Value) (bool, error) {
-	field := v.FieldByName(s.field)
-	return reflect.DeepEqual(field.Interface(), s.value), nil
+func (s *strictEq) MatchField(v interface{}) (bool, error) {
+	return reflect.DeepEqual(v, s.value), nil
 }
 
 // Eq matcher, checks if the given field is equal to the given value
-func Eq(field string, v interface{}) Matcher { return &cmp{field: field, value: v, token: token.EQL} }
+func Eq(field string, v interface{}) Matcher {
+	return NewFieldMatcher(field, &cmp{value: v, token: token.EQL})
+}
 
 // StrictEq matcher, checks if the given field is deeply equal to the given value
-func StrictEq(field string, v interface{}) Matcher { return &strictEq{field: field, value: v} }
+func StrictEq(field string, v interface{}) Matcher {
+	return NewFieldMatcher(field, &strictEq{value: v})
+}
 
 // Gt matcher, checks if the given field is greater than the given value
-func Gt(field string, v interface{}) Matcher { return &cmp{field: field, value: v, token: token.GTR} }
+func Gt(field string, v interface{}) Matcher {
+	return NewFieldMatcher(field, &cmp{value: v, token: token.GTR})
+}
 
 // Gte matcher, checks if the given field is greater than or equal to the given value
-func Gte(field string, v interface{}) Matcher { return &cmp{field: field, value: v, token: token.GEQ} }
+func Gte(field string, v interface{}) Matcher {
+	return NewFieldMatcher(field, &cmp{value: v, token: token.GEQ})
+}
 
 // Lt matcher, checks if the given field is lesser than the given value
-func Lt(field string, v interface{}) Matcher { return &cmp{field: field, value: v, token: token.LSS} }
+func Lt(field string, v interface{}) Matcher {
+	return NewFieldMatcher(field, &cmp{value: v, token: token.LSS})
+}
 
 // Lte matcher, checks if the given field is lesser than or equal to the given value
-func Lte(field string, v interface{}) Matcher { return &cmp{field: field, value: v, token: token.LEQ} }
+func Lte(field string, v interface{}) Matcher {
+	return NewFieldMatcher(field, &cmp{value: v, token: token.LEQ})
+}
 
 // True matcher, always returns true
 func True() Matcher { return &trueMatcher{} }


### PR DESCRIPTION
This is a convienient way of creating the most common Matcher for single fields.

This lets people concentrate on the matching logic and avoid having to duplicate fragile reflection constructs.

I'm not totally happy about the names, and I would be happy if someone could suggest a cleaner way of doing this.

But as I added some matchers for myself yesterday, I was a little put off by this reflection copy-and-paste.