### PR TITLE
fixed update save bug

### DIFF
--- a/save.go
+++ b/save.go
@@ -70,10 +70,12 @@ func (n *node) save(tx *bolt.Tx, info *modelInfo, id []byte, raw []byte, data in
 		}
 	}
 
-	if n.s.autoIncrement {
-		raw, err = n.s.codec.Encode(data)
-		if err != nil {
-			return err
+	if data != nil {
+		if n.s.autoIncrement {
+			raw, err = n.s.codec.Encode(data)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
update something data have a bug 

```
panic: reflect: call of reflect.Value.Type on zero Value [recovered]
        panic: reflect: call of reflect.Value.Type on zero Value
goroutine 5 [running]:
panic(0x1c9b00, 0xc4202044a0)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
testing.tRunner.func1(0xc42008c240)
        /usr/local/go/src/testing/testing.go:579 +0x25d
panic(0x1c9b00, 0xc4202044a0)
        /usr/local/go/src/runtime/panic.go:458 +0x243
reflect.Value.Type(0x0, 0x0, 0x0, 0xfe01, 0x30f320)
        /usr/local/go/src/reflect/value.go:1670 +0x224
encoding/gob.(*Encoder).EncodeValue(0xc4201fe1e0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/local/go/src/encoding/gob/encoder.go:230 +0xe9
encoding/gob.(*Encoder).Encode(0xc4201fe1e0, 0x0, 0x0, 0x30ec00, 0xb)
        /usr/local/go/src/encoding/gob/encoder.go:175 +0x61
github.com/asdine/storm/codec/gob.gobCodec.Encode(0x0, 0x0, 0x0, 0xc4201e79a0, 0xb, 0x0, 0x0, 0xb)
        /Golang/src/github.com/asdine/storm/codec/gob/gob.go:18 +0x93
github.com/asdine/storm/codec/gob.(*gobCodec).Encode(0xc420191570, 0x0, 0x0, 0x1, 0x1, 0x0, 0x0, 0xc4200e7610)
        <autogenerated>:1 +0x66
github.com/wanliu/rbacserver/vendor/github.com/asdine/storm.(*node).save(0xc4201c9b30, 0xc420106d20, 0xc4201db640, 0xc4201e3fa4, 0x4, 0x40, 0xc4201f66c0, 0x1ce, 0x22d, 0x0, ...)
        /Golang/src/github.com/wanliu/rbacserver/vendor/github.com/asdine/storm/save.go:77 +0x7e3
github.com/wanliu/rbacserver/vendor/github.com/asdine/storm.(*node).update(0xc4201c8570, 0x1b1ee0, 0xc4201f8680, 0xc4200e78d8, 0x0, 0x0)
        /Golang/src/github.com/wanliu/rbacserver/vendor/github.com/asdine/storm/update.go:106 +0x93a
```

I track source , guess maybe in call `update` nest call `save` func pass `nil` data , can't be encoded

start ->  https://github.com/asdine/storm/blob/master/update.go#L101
```           
	err = ntx.save(ntx.tx, info, id, raw, nil)
        // 5's argument  is nil

	if err != nil {
		return err
	}
```
enter save -> https://github.com/asdine/storm/blob/master/save.go#L74
```
	if n.s.autoIncrement {
		raw, err = n.s.codec.Encode(data)
                // data is nil
		if err != nil {
			return err
		}
	}
```
`data` is nil encode is failed
