### PR TITLE
Added stringer check for structs

### DIFF
--- a/q/compare.go
+++ b/q/compare.go
@@ -1,6 +1,7 @@
 package q
 
 import (
+	"fmt"
 	"go/constant"
 	"go/token"
 	"reflect"
@@ -50,6 +51,24 @@ func compare(a, b interface{}, tok token.Token) bool {
 		}
 	case ak == reflect.String:
 		if bk == reflect.String {
+			return constant.Compare(constant.MakeString(vala.String()), tok, constant.MakeString(valb.String()))
+		}
+
+		st := reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+		bt := reflect.TypeOf(b)
+		if bt.Implements(st) {
+			return constant.Compare(constant.MakeString(vala.String()), tok, constant.MakeString(valb.String()))
+		}
+	case ak == reflect.Struct:
+		st := reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+		at := reflect.TypeOf(a)
+		bt := reflect.TypeOf(b)
+
+		if at.Implements(st) && bt.Implements(st) {
+			return constant.Compare(constant.MakeString(vala.String()), tok, constant.MakeString(valb.String()))
+		}
+
+		if at.Implements(st) && bk == reflect.String {
 			return constant.Compare(constant.MakeString(vala.String()), tok, constant.MakeString(valb.String()))
 		}
 	case tok == token.EQL:

--- a/q/tree_test.go
+++ b/q/tree_test.go
@@ -3,6 +3,7 @@ package q
 import (
 	"go/token"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -24,6 +25,7 @@ func TestCompare(t *testing.T) {
 	assert.True(t, compare(10.0, "10.0", token.EQL))
 	assert.False(t, compare(10.0, "hello", token.EQL))
 	assert.True(t, compare("hello", "hello", token.EQL))
+	assert.False(t, compare(time.Date(2016, time.January, 29, 16, 20, 0, 0, time.UTC), time.Date(2016, time.September, 29, 16, 20, 0, 0, time.UTC), token.GTR))
 	assert.True(t, compare(&User{Name: "John"}, &User{Name: "John"}, token.EQL))
 	assert.False(t, compare(&User{Name: "John"}, &User{Name: "Jack"}, token.GTR))
 	assert.True(t, compare(10, 5.0, token.GTR))


### PR DESCRIPTION
This PR is probably a quite poor check. But it works for my checks.
I will update here if tests fail or if you have any enhancements.

Info:
Added the possibility to compare `fmt.Stringer` structs.
The special case was `time.Time()` sturcts which should be compared.

This commit closes #96
