### PR TITLE
Count on initialised but empty database return an error

### DIFF
--- a/finder_test.go
+++ b/finder_test.go
@@ -363,6 +363,19 @@ func TestCount(t *testing.T) {
 	tx.Commit()
 }
 
+func TestCountEmpty(t *testing.T) {
+	db, cleanup := createDB(t)
+	defer cleanup()
+
+	user := &User{}
+	err := db.Init(user)
+	assert.NoError(t, err)
+
+	count, err := db.Count(user)
+	assert.Zero(t, count)
+	assert.NoError(t, err)
+}
+
 func TestOne(t *testing.T) {
 	db, cleanup := createDB(t)
 	defer cleanup()

--- a/sink.go
+++ b/sink.go
@@ -376,10 +376,6 @@ func (c *countSink) add(i *item) (bool, error) {
 }
 
 func (c *countSink) flush() error {
-	if c.counter == 0 {
-		return ErrNotFound
-	}
-
 	return nil
 }
 

--- a/storm.go
+++ b/storm.go
@@ -272,7 +272,7 @@ func (s *DB) checkVersion() error {
 	}
 
 	// for now, we only set the current version if it doesn't exist or if v0.5.0
-	if v == "" || v == "0.5.0" {
+	if v == "" || v == "0.5.0" || v == "0.6.0" {
 		return s.Set(dbinfo, "version", Version)
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package storm
 
 // Version of Storm
-const Version = "0.6.0"
+const Version = "0.6.1"


### PR DESCRIPTION
This add the failing test that reproduce #112

```
go test
--- FAIL: TestCountEmpty (0.00s)
        Error Trace:    finder_test.go:376
	Error:		Received unexpected error "not found"

FAIL
exit status 1
FAIL	github.com/asdine/storm	1.331s
```