### PR TITLE
PrefixScan and RangeScan return only buckets

### DIFF
--- a/finder_test.go
+++ b/finder_test.go
@@ -385,7 +385,7 @@ func TestCount(t *testing.T) {
 	tx, err := db.Begin(true)
 	assert.NoError(t, err)
 
-	count, err = tx.Count(User{})
+	_, err = tx.Count(User{})
 	assert.Equal(t, ErrStructPtrNeeded, err)
 
 	count, err = tx.Count(&User{})

--- a/scan.go
+++ b/scan.go
@@ -38,7 +38,11 @@ func (n *node) prefixScan(tx *bolt.Tx, prefix string) []Node {
 		c           = n.cursor(tx)
 	)
 
-	for k, _ := c.Seek(prefixBytes); k != nil && bytes.HasPrefix(k, prefixBytes); k, _ = c.Next() {
+	for k, v := c.Seek(prefixBytes); k != nil && bytes.HasPrefix(k, prefixBytes); k, v = c.Next() {
+		if v != nil {
+			continue
+		}
+
 		nodes = append(nodes, n.From(string(k)))
 	}
 
@@ -69,7 +73,11 @@ func (n *node) rangeScan(tx *bolt.Tx, min, max string) []Node {
 		c        = n.cursor(tx)
 	)
 
-	for k, _ := c.Seek(minBytes); k != nil && bytes.Compare(k, maxBytes) <= 0; k, _ = c.Next() {
+	for k, v := c.Seek(minBytes); k != nil && bytes.Compare(k, maxBytes) <= 0; k, v = c.Next() {
+		if v != nil {
+			continue
+		}
+
 		nodes = append(nodes, n.From(string(k)))
 	}
 

--- a/scan_test.go
+++ b/scan_test.go
@@ -57,6 +57,18 @@ func TestPrefixScanWithEmptyPrefix(t *testing.T) {
 	require.Len(t, res, 1)
 }
 
+func TestPrefixScanSkipValues(t *testing.T) {
+	db, cleanup := createDB(t)
+	defer cleanup()
+
+	db.Set("a", "2015", 1)
+	err := db.From("a", "2016").Save(&SimpleUser{ID: 1, Name: "John"})
+	require.NoError(t, err)
+
+	res := db.From("a").PrefixScan("20")
+	require.Len(t, res, 1)
+}
+
 func TestRangeScan(t *testing.T) {
 	db, cleanup := createDB(t)
 	defer cleanup()
@@ -88,4 +100,16 @@ func doTestRangeScan(t *testing.T, node Node) {
 
 	secondIn2015 := node.RangeScan("2015", "2016")[1]
 	assert.NoError(t, secondIn2015.One("ID", 2, &SimpleUser{}))
+}
+
+func TestRangeScanSkipValues(t *testing.T) {
+	db, cleanup := createDB(t)
+	defer cleanup()
+
+	db.Set("a", "2015", 1)
+	err := db.From("a", "2016").Save(&SimpleUser{ID: 1, Name: "John"})
+	require.NoError(t, err)
+
+	res := db.From("a").RangeScan("2015", "2018")
+	require.Len(t, res, 1)
 }


### PR DESCRIPTION
See #117 