### PR TITLE
Add method to Node to return the current transaction

### DIFF
--- a/node.go
+++ b/node.go
@@ -40,6 +40,9 @@ type Node interface {
 
 	// WithBatch returns a new Storm Node with the batch mode enabled.
 	WithBatch(enabled bool) Node
+
+	// Transaction returns the transaction (if any) from the node.
+	Transaction() *bolt.Tx
 }
 
 // A Node in Storm represents the API to a BoltDB bucket.
@@ -82,6 +85,11 @@ func (n node) WithCodec(codec codec.MarshalUnmarshaler) Node {
 func (n node) WithBatch(enabled bool) Node {
 	n.batchMode = enabled
 	return &n
+}
+
+// Transaction returns the transaction (if any) from the node.
+func (n node) Transaction() *bolt.Tx {
+	return n.tx
 }
 
 // Bucket returns the bucket name as a slice from the root.

--- a/storm.go
+++ b/storm.go
@@ -137,6 +137,11 @@ func (s *DB) WithBatch(enabled bool) Node {
 	return n
 }
 
+// Transaction returns the transaction (if any) from the node.
+func (s *DB) Transaction() *bolt.Tx {
+	return s.root.tx
+}
+
 // Get a value from a bucket
 func (s *DB) Get(bucketName string, key interface{}, to interface{}) error {
 	return s.root.Get(bucketName, key, to)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -22,6 +22,7 @@ func TestTransaction(t *testing.T) {
 	ntx, ok := tx.(*node)
 	assert.True(t, ok)
 	assert.NotNil(t, ntx.tx)
+	assert.Equal(t, tx.Transaction(), ntx.tx)
 
 	err = tx.Init(&SimpleUser{})
 	assert.NoError(t, err)


### PR DESCRIPTION
This facilitates passing a transaction between nodes to bundle changes
into a single transaction.

Fixes #146