### PR TITLE
Prefix method

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,44 +11,41 @@ In addition to the examples below, see also the [examples in the GoDoc](https://
 
 ## Table of Contents
 
-<!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:0 orderedList:0 -->
-
 - [Getting Started](#getting-started)
 - [Import Storm](#import-storm)
 - [Open a database](#open-a-database)
 - [Simple CRUD system](#simple-crud-system)
-	- [Declare your structures](#declare-your-structures)
-	- [Save your object](#save-your-object)
-		- [Auto Increment](#auto-increment)
-	- [Simple queries](#simple-queries)
-		- [Fetch one object](#fetch-one-object)
-		- [Fetch multiple objects](#fetch-multiple-objects)
-		- [Fetch all objects](#fetch-all-objects)
-		- [Fetch all objects sorted by index](#fetch-all-objects-sorted-by-index)
-		- [Fetch a range of objects](#fetch-a-range-of-objects)
-		- [Skip, Limit and Reverse](#skip-limit-and-reverse)
-		- [Delete an object](#delete-an-object)
-		- [Update an object](#update-an-object)
-		- [Initialize buckets and indexes before saving an object](#initialize-buckets-and-indexes-before-saving-an-object)
-		- [Drop a bucket](#drop-a-bucket)
-		- [Re-index a bucket](#re-index-a-bucket)
-	- [Advanced queries](#advanced-queries)
-	- [Transactions](#transactions)
-	- [Options](#options)
-		- [BoltOptions](#boltoptions)
-		- [MarshalUnmarshaler](#marshalunmarshaler)
-			- [Provided Codecs](#provided-codecs)
-		- [Use existing Bolt connection](#use-existing-bolt-connection)
-		- [Batch mode](#batch-mode)
+  - [Declare your structures](#declare-your-structures)
+  - [Save your object](#save-your-object)
+    - [Auto Increment](#auto-increment)
+  - [Simple queries](#simple-queries)
+    - [Fetch one object](#fetch-one-object)
+    - [Fetch multiple objects](#fetch-multiple-objects)
+    - [Fetch all objects](#fetch-all-objects)
+    - [Fetch all objects sorted by index](#fetch-all-objects-sorted-by-index)
+    - [Fetch a range of objects](#fetch-a-range-of-objects)
+    - [Fetch objects by prefix](#fetch-objects-by-prefix)
+    - [Skip, Limit and Reverse](#skip-limit-and-reverse)
+    - [Delete an object](#delete-an-object)
+    - [Update an object](#update-an-object)
+    - [Initialize buckets and indexes before saving an object](#initialize-buckets-and-indexes-before-saving-an-object)
+    - [Drop a bucket](#drop-a-bucket)
+    - [Re-index a bucket](#re-index-a-bucket)
+  - [Advanced queries](#advanced-queries)
+  - [Transactions](#transactions)
+  - [Options](#options)
+    - [BoltOptions](#boltoptions)
+    - [MarshalUnmarshaler](#marshalunmarshaler)
+      - [Provided Codecs](#provided-codecs)
+    - [Use existing Bolt connection](#use-existing-bolt-connection)
+    - [Batch mode](#batch-mode)
 - [Nodes and nested buckets](#nodes-and-nested-buckets)
-	- [Node options](#node-options)
+  - [Node options](#node-options)
 - [Simple Key/Value store](#simple-keyvalue-store)
 - [BoltDB](#boltdb)
 - [Migrations](#migrations)
 - [License](#license)
 - [Credits](#credits)
-
-<!-- /TOC -->
 
 ## Getting Started
 
@@ -220,6 +217,13 @@ err := db.AllByIndex("CreatedAt", &users)
 ```go
 var users []User
 err := db.Range("Age", 10, 21, &users)
+```
+
+#### Fetch objects by prefix
+
+```go
+var users []User
+err := db.Prefix("Name", "Jo", &users)
 ```
 
 #### Skip, Limit and Reverse

--- a/index/indexes.go
+++ b/index/indexes.go
@@ -10,4 +10,5 @@ type Index interface {
 	All(value []byte, opts *Options) ([][]byte, error)
 	AllRecords(opts *Options) ([][]byte, error)
 	Range(min []byte, max []byte, opts *Options) ([][]byte, error)
+	Prefix(prefix []byte, opts *Options) ([][]byte, error)
 }

--- a/storm.go
+++ b/storm.go
@@ -187,6 +187,11 @@ func (s *DB) Range(fieldName string, min, max, to interface{}, options ...func(*
 	return s.root.Range(fieldName, min, max, to, options...)
 }
 
+// Prefix returns one or more records whose given field starts with the specified prefix.
+func (s *DB) Prefix(fieldName string, prefix string, to interface{}, options ...func(*index.Options)) error {
+	return s.root.Prefix(fieldName, prefix, to, options...)
+}
+
 // AllByIndex gets all the records of a bucket that are indexed in the specified index
 func (s *DB) AllByIndex(fieldName string, to interface{}, options ...func(*index.Options)) error {
 	return s.root.AllByIndex(fieldName, to, options...)


### PR DESCRIPTION
This PR adds a `Prefix` method. It uses indexes when available, otherwise it does a bucket scan using `q.Re("^prefix")`
Fixes #179 