### PR TITLE
Added *time.Time comparison for q

### DIFF
--- a/q/compare.go
+++ b/q/compare.go
@@ -88,7 +88,20 @@ func compare(a, b interface{}, tok token.Token) bool {
 		}
 	}
 
-	if reflect.TypeOf(a).String() == "time.Time" && reflect.TypeOf(b).String() == "time.Time" {
+	if (reflect.TypeOf(a).String() == "time.Time" || reflect.TypeOf(a).String() == "*time.Time") &&
+		(reflect.TypeOf(b).String() == "time.Time" || reflect.TypeOf(b).String() == "*time.Time") {
+
+		if reflect.TypeOf(a).String() == "*time.Time" && vala.IsNil() {
+			return true
+		}
+
+		if reflect.TypeOf(b).String() == "*time.Time" {
+			if valb.IsNil() {
+				return true
+			}
+			valb = valb.Elem()
+		}
+
 		var x, y int64
 		x = 1
 		if vala.MethodByName("Equal").Call([]reflect.Value{valb})[0].Bool() {

--- a/q/compare.go
+++ b/q/compare.go
@@ -88,14 +88,16 @@ func compare(a, b interface{}, tok token.Token) bool {
 		}
 	}
 
-	if reflect.TypeOf(a) != nil && (reflect.TypeOf(a).String() == "time.Time" || reflect.TypeOf(a).String() == "*time.Time") &&
-		reflect.TypeOf(b) != nil && (reflect.TypeOf(b).String() == "time.Time" || reflect.TypeOf(b).String() == "*time.Time") {
+	typea, typeb := reflect.TypeOf(a), reflect.TypeOf(b)
 
-		if reflect.TypeOf(a).String() == "*time.Time" && vala.IsNil() {
+	if typea != nil && (typea.String() == "time.Time" || typea.String() == "*time.Time") &&
+		typeb != nil && (typeb.String() == "time.Time" || typeb.String() == "*time.Time") {
+
+		if typea.String() == "*time.Time" && vala.IsNil() {
 			return true
 		}
 
-		if reflect.TypeOf(b).String() == "*time.Time" {
+		if typeb.String() == "*time.Time" {
 			if valb.IsNil() {
 				return true
 			}

--- a/q/compare.go
+++ b/q/compare.go
@@ -88,8 +88,8 @@ func compare(a, b interface{}, tok token.Token) bool {
 		}
 	}
 
-	if (reflect.TypeOf(a).String() == "time.Time" || reflect.TypeOf(a).String() == "*time.Time") &&
-		(reflect.TypeOf(b).String() == "time.Time" || reflect.TypeOf(b).String() == "*time.Time") {
+	if reflect.TypeOf(a) != nil && (reflect.TypeOf(a).String() == "time.Time" || reflect.TypeOf(a).String() == "*time.Time") &&
+		reflect.TypeOf(b) != nil && (reflect.TypeOf(b).String() == "time.Time" || reflect.TypeOf(b).String() == "*time.Time") {
 
 		if reflect.TypeOf(a).String() == "*time.Time" && vala.IsNil() {
 			return true

--- a/q/tree_test.go
+++ b/q/tree_test.go
@@ -2,6 +2,7 @@ package q
 
 import (
 	"go/token"
+	"reflect"
 	"testing"
 	"time"
 
@@ -36,9 +37,25 @@ func TestCompare(t *testing.T) {
 	t1 := time.Now()
 	t2 := t1.Add(2 * time.Hour)
 	t3 := t1.Add(-2 * time.Hour)
+	tnil := reflect.Zero(reflect.TypeOf(&t1)).Interface()
 	require.True(t, compare(t1, t1, token.EQL))
 	require.True(t, compare(t1, t2, token.LSS))
 	require.True(t, compare(t1, t3, token.GTR))
+	require.True(t, compare(&t1, t1, token.EQL))
+	require.True(t, compare(&t1, t2, token.LSS))
+	require.True(t, compare(&t1, t3, token.GTR))
+	require.True(t, compare(&t1, &t1, token.EQL))
+	require.True(t, compare(&t1, &t2, token.LSS))
+	require.True(t, compare(&t1, &t3, token.GTR))
+	require.True(t, compare(t1, &t1, token.EQL))
+	require.True(t, compare(t1, &t2, token.LSS))
+	require.True(t, compare(t1, &t3, token.GTR))
+	require.True(t, compare(tnil, t1, token.EQL))
+	require.True(t, compare(tnil, t2, token.LSS))
+	require.True(t, compare(tnil, t3, token.GTR))
+	require.True(t, compare(t1, tnil, token.EQL))
+	require.True(t, compare(t1, tnil, token.LSS))
+	require.True(t, compare(t1, tnil, token.GTR))
 	require.False(t, compare(&A{Name: "John"}, t1, token.EQL))
 	require.False(t, compare(&A{Name: "John"}, t1, token.LEQ))
 	require.True(t, compare(uint32(10), uint32(5), token.GTR))

--- a/q/tree_test.go
+++ b/q/tree_test.go
@@ -56,6 +56,8 @@ func TestCompare(t *testing.T) {
 	require.True(t, compare(t1, tnil, token.EQL))
 	require.True(t, compare(t1, tnil, token.LSS))
 	require.True(t, compare(t1, tnil, token.GTR))
+	require.False(t, compare(nil, t1, token.EQL))
+	require.False(t, compare(t1, nil, token.EQL))
 	require.False(t, compare(&A{Name: "John"}, t1, token.EQL))
 	require.False(t, compare(&A{Name: "John"}, t1, token.LEQ))
 	require.True(t, compare(uint32(10), uint32(5), token.GTR))


### PR DESCRIPTION
Enhanced version of https://github.com/asdine/storm/pull/98.

It allows to compare both `time.Time` and `*time.Time`.

Let me know if there are any places that need changes