### PR TITLE
v3: use semantic import versioning as required by go

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ go get -u github.com/asdine/storm
 ## Import Storm
 
 ```go
-import "github.com/asdine/storm"
+import "github.com/asdine/storm/v3"
 ```
 
 ## Open a database
@@ -470,12 +470,12 @@ These can be used by importing the relevant package and use that codec to config
 
 ```go
 import (
-  "github.com/asdine/storm"
-  "github.com/asdine/storm/codec/gob"
-  "github.com/asdine/storm/codec/json"
-  "github.com/asdine/storm/codec/sereal"
-  "github.com/asdine/storm/codec/protobuf"
-  "github.com/asdine/storm/codec/msgpack"
+  "github.com/asdine/storm/v3"
+  "github.com/asdine/storm/v3/codec/gob"
+  "github.com/asdine/storm/v3/codec/json"
+  "github.com/asdine/storm/v3/codec/sereal"
+  "github.com/asdine/storm/v3/codec/protobuf"
+  "github.com/asdine/storm/v3/codec/msgpack"
 )
 
 var gobDb, _ = storm.Open("gob.db", storm.Codec(gob.Codec))

--- a/codec/example_test.go
+++ b/codec/example_test.go
@@ -3,12 +3,12 @@ package codec_test
 import (
 	"fmt"
 
-	"github.com/asdine/storm"
-	"github.com/asdine/storm/codec/gob"
-	"github.com/asdine/storm/codec/json"
-	"github.com/asdine/storm/codec/msgpack"
-	"github.com/asdine/storm/codec/protobuf"
-	"github.com/asdine/storm/codec/sereal"
+	"github.com/asdine/storm/v3"
+	"github.com/asdine/storm/v3/codec/gob"
+	"github.com/asdine/storm/v3/codec/json"
+	"github.com/asdine/storm/v3/codec/msgpack"
+	"github.com/asdine/storm/v3/codec/protobuf"
+	"github.com/asdine/storm/v3/codec/sereal"
 )
 
 func Example() {

--- a/codec/gob/gob_test.go
+++ b/codec/gob/gob_test.go
@@ -3,7 +3,7 @@ package gob
 import (
 	"testing"
 
-	"github.com/asdine/storm/codec/internal"
+	"github.com/asdine/storm/v3/codec/internal"
 )
 
 func TestGob(t *testing.T) {

--- a/codec/internal/test_helpers.go
+++ b/codec/internal/test_helpers.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/asdine/storm/codec"
+	"github.com/asdine/storm/v3/codec"
 )
 
 type testStruct struct {

--- a/codec/json/json_test.go
+++ b/codec/json/json_test.go
@@ -3,7 +3,7 @@ package json
 import (
 	"testing"
 
-	"github.com/asdine/storm/codec/internal"
+	"github.com/asdine/storm/v3/codec/internal"
 )
 
 func TestJSON(t *testing.T) {

--- a/codec/msgpack/msgpack_test.go
+++ b/codec/msgpack/msgpack_test.go
@@ -3,7 +3,7 @@ package msgpack
 import (
 	"testing"
 
-	"github.com/asdine/storm/codec/internal"
+	"github.com/asdine/storm/v3/codec/internal"
 )
 
 func TestMsgpack(t *testing.T) {

--- a/codec/protobuf/protobuf.go
+++ b/codec/protobuf/protobuf.go
@@ -4,7 +4,7 @@ package protobuf
 import (
 	"errors"
 
-	"github.com/asdine/storm/codec/json"
+	"github.com/asdine/storm/v3/codec/json"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/codec/protobuf/protobuf_test.go
+++ b/codec/protobuf/protobuf_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/asdine/storm"
-	"github.com/asdine/storm/codec/internal"
+	"github.com/asdine/storm/v3"
+	"github.com/asdine/storm/v3/codec/internal"
 	"github.com/stretchr/testify/require"
 )
 

--- a/codec/sereal/sereal_test.go
+++ b/codec/sereal/sereal_test.go
@@ -3,7 +3,7 @@ package sereal
 import (
 	"testing"
 
-	"github.com/asdine/storm/codec/internal"
+	"github.com/asdine/storm/v3/codec/internal"
 	"github.com/stretchr/testify/require"
 )
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/asdine/storm"
-	"github.com/asdine/storm/codec/gob"
+	"github.com/asdine/storm/v3"
+	"github.com/asdine/storm/v3/codec/gob"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/extract.go
+++ b/extract.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/asdine/storm/index"
+	"github.com/asdine/storm/v3/index"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/finder.go
+++ b/finder.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/asdine/storm/index"
-	"github.com/asdine/storm/q"
+	"github.com/asdine/storm/v3/index"
+	"github.com/asdine/storm/v3/q"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/asdine/storm
+module github.com/asdine/storm/v3
 
 require (
 	github.com/Sereal/Sereal v0.0.0-20190618215532-0b8ac451a863
@@ -10,3 +10,5 @@ require (
 	github.com/vmihailenco/msgpack v4.0.1+incompatible
 	go.etcd.io/bbolt v1.3.0
 )
+
+go 1.13

--- a/index/list.go
+++ b/index/list.go
@@ -3,7 +3,7 @@ package index
 import (
 	"bytes"
 
-	"github.com/asdine/storm/internal"
+	"github.com/asdine/storm/v3/internal"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/index/list_test.go
+++ b/index/list_test.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/asdine/storm"
-	"github.com/asdine/storm/codec/gob"
-	"github.com/asdine/storm/index"
+	"github.com/asdine/storm/v3"
+	"github.com/asdine/storm/v3/codec/gob"
+	"github.com/asdine/storm/v3/index"
 	bolt "go.etcd.io/bbolt"
 	"github.com/stretchr/testify/require"
 )

--- a/index/unique.go
+++ b/index/unique.go
@@ -3,7 +3,7 @@ package index
 import (
 	"bytes"
 
-	"github.com/asdine/storm/internal"
+	"github.com/asdine/storm/v3/internal"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/index/unique_test.go
+++ b/index/unique_test.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/asdine/storm"
-	"github.com/asdine/storm/codec/gob"
-	"github.com/asdine/storm/index"
+	"github.com/asdine/storm/v3"
+	"github.com/asdine/storm/v3/codec/gob"
+	"github.com/asdine/storm/v3/index"
 	bolt "go.etcd.io/bbolt"
 	"github.com/stretchr/testify/require"
 )

--- a/kv_test.go
+++ b/kv_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/asdine/storm/codec/gob"
-	"github.com/asdine/storm/codec/json"
+	"github.com/asdine/storm/v3/codec/gob"
+	"github.com/asdine/storm/v3/codec/json"
 	bolt "go.etcd.io/bbolt"
 	"github.com/stretchr/testify/require"
 )

--- a/node.go
+++ b/node.go
@@ -1,7 +1,7 @@
 package storm
 
 import (
-	"github.com/asdine/storm/codec"
+	"github.com/asdine/storm/v3/codec"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/node_test.go
+++ b/node_test.go
@@ -3,8 +3,8 @@ package storm
 import (
 	"testing"
 
-	"github.com/asdine/storm/codec/gob"
-	"github.com/asdine/storm/codec/json"
+	"github.com/asdine/storm/v3/codec/gob"
+	"github.com/asdine/storm/v3/codec/json"
 	bolt "go.etcd.io/bbolt"
 	"github.com/stretchr/testify/require"
 )

--- a/options.go
+++ b/options.go
@@ -3,8 +3,8 @@ package storm
 import (
 	"os"
 
-	"github.com/asdine/storm/codec"
-	"github.com/asdine/storm/index"
+	"github.com/asdine/storm/v3/codec"
+	"github.com/asdine/storm/v3/index"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/q/examples_test.go
+++ b/q/examples_test.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/asdine/storm"
-	"github.com/asdine/storm/q"
+	"github.com/asdine/storm/v3"
+	"github.com/asdine/storm/v3/q"
 )
 
 func ExampleRe() {

--- a/query.go
+++ b/query.go
@@ -1,8 +1,8 @@
 package storm
 
 import (
-	"github.com/asdine/storm/internal"
-	"github.com/asdine/storm/q"
+	"github.com/asdine/storm/v3/internal"
+	"github.com/asdine/storm/v3/q"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/query_test.go
+++ b/query_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/asdine/storm/codec/json"
-	"github.com/asdine/storm/q"
+	"github.com/asdine/storm/v3/codec/json"
+	"github.com/asdine/storm/v3/q"
 	"github.com/stretchr/testify/require"
 )
 

--- a/sink.go
+++ b/sink.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"sort"
 	"time"
-	"github.com/asdine/storm/index"
-	"github.com/asdine/storm/q"
+	"github.com/asdine/storm/v3/index"
+	"github.com/asdine/storm/v3/q"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/store.go
+++ b/store.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"reflect"
 
-	"github.com/asdine/storm/index"
-	"github.com/asdine/storm/q"
+	"github.com/asdine/storm/v3/index"
+	"github.com/asdine/storm/v3/q"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/store_test.go
+++ b/store_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/asdine/storm/codec/gob"
-	"github.com/asdine/storm/codec/json"
-	"github.com/asdine/storm/q"
+	"github.com/asdine/storm/v3/codec/gob"
+	"github.com/asdine/storm/v3/codec/json"
+	"github.com/asdine/storm/v3/q"
 	"github.com/stretchr/testify/require"
 	bolt "go.etcd.io/bbolt"
 )

--- a/storm.go
+++ b/storm.go
@@ -5,8 +5,8 @@ import (
 	"encoding/binary"
 	"time"
 
-	"github.com/asdine/storm/codec"
-	"github.com/asdine/storm/codec/json"
+	"github.com/asdine/storm/v3/codec"
+	"github.com/asdine/storm/v3/codec/json"
 	bolt "go.etcd.io/bbolt"
 )
 

--- a/storm_test.go
+++ b/storm_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/asdine/storm/codec/json"
+	"github.com/asdine/storm/v3/codec/json"
 	bolt "go.etcd.io/bbolt"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
Resolving https://github.com/asdine/storm/issues/255

Note that this will require a `v3.0.0` tag once merged to be usable by dependents.