### PR TITLE
Rename the AES Codec package to aes

### DIFF
--- a/codec/aes/aes.go
+++ b/codec/aes/aes.go
@@ -1,4 +1,4 @@
-package database
+package aes
 
 import (
 	"crypto/aes"

--- a/codec/aes/aes_test.go
+++ b/codec/aes/aes_test.go
@@ -1,4 +1,4 @@
-package database
+package aes
 
 import (
 	"encoding/base64"


### PR DESCRIPTION
I just noted that I rather foolishly forgot to rename the package name for the new codec in the last MR #270 .