### PR TITLE
Fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ _For extended queries and support for [Badger](https://github.com/dgraph-io/badg
 ## Getting Started
 
 ```bash
-go get -u github.com/asdine/storm
+GO111MODULE=on go get -u github.com/asdine/storm/v3
 ```
 
 ## Import Storm


### PR DESCRIPTION
The previous install command didn't install v3 for me, because it wasn't specified in the URL. This changes it so v3 is installed correctly.