### PR TITLE
Update README for zero-value fields updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,9 +250,11 @@ err := db.DeleteStruct(&user)
 
 ```go
 // Update multiple fields
+// Only works for non zero-value fields (e.g. Name can not be "", Age can not be 0)
 err := db.Update(&User{ID: 10, Name: "Jack", Age: 45})
 
 // Update a single field
+// Also works for zero-value fields (0, false, "", ...)
 err := db.UpdateField(&User{ID: 10}, "Age", 0)
 ```
 


### PR DESCRIPTION
I just add two more comments to the Update section of the code examples, since it was not obvious to me that you can not Update() fields when you want to set them to their zero-value. You have to use UpdateField() for that